### PR TITLE
fix(docs): manager -> mgr

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ya pack -a ourongxing/fast-enter
 Then bind it for `l` key, in your `keymap.toml`:
 
 ```toml
-[[manager.prepend_keymap]]
+[[mgr.prepend_keymap]]
 on   = [ "l" ]
 run  = "plugin fast-enter"
 desc = "Enter the subfolder faster, or open the file directly"


### PR DESCRIPTION
 `[manager]` has been deprecated in favor of the new `[mgr]`, see #2803 for more details: https://github.com/sxyazi/yazi/pull/2803